### PR TITLE
fix (assumed) typo

### DIFF
--- a/src/unstated.js
+++ b/src/unstated.js
@@ -132,7 +132,7 @@ export function Provider(props: ProviderProps) {
 
         return (
           <StateContext.Provider value={childMap}>
-            {this.props.children}
+            {props.children}
           </StateContext.Provider>
         );
       }}


### PR DESCRIPTION
Upon a clone and running the examples, getting `this` undefined errors