### PR TITLE
Add create-react-context to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Installation
 
 ```sh
-yarn add unstated
+yarn add unstated create-react-context
 ```
 
 ## Example


### PR DESCRIPTION
Because `create-react-context` is a peer deps, it will no be installed. Right now I didn't expect to get any error following the simple example but I had to install the deps first.