### PR TITLE
Add typings and tests for TypeScript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ cache:
   yarn: true
   directories:
   - node_modules
-script: yarn test && yarn flow
+script: 
+  - yarn test && yarn flow
+  - yarn typescript

--- a/__tests__/unstated.tsx
+++ b/__tests__/unstated.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { Provider, Subscribe, Container } from '../src/unstated';
+
+class CounterContainer extends Container<{ count: number }> {
+  state = { count: 0 };
+  increment(amount = 1) {
+    this.setState({ count: this.state.count + amount });
+  }
+  decrement(amount = 1) {
+    this.setState({ count: this.state.count - amount });
+  }
+}
+
+class AmounterContainer extends Container<{ amount: number }> {
+  state = { amount: 1 };
+  setAmount(amount) {
+    this.setState({ amount });
+  }
+}
+
+function Counter() {
+  return (
+    <Subscribe to={[CounterContainer]}>
+      {(counter: CounterContainer) => (
+        <div>
+          <span>{counter.state.count}</span>
+          <button onClick={() => counter.decrement()}>-</button>
+          <button onClick={() => counter.increment()}>+</button>
+        </div>
+      )}
+    </Subscribe>
+  );
+}
+
+function CounterWithAmount() {
+  return (
+    <Subscribe to={[CounterContainer, AmounterContainer]}>
+      {(counter: CounterContainer, amounter: AmounterContainer) => (
+        <div>
+          <span>{counter.state.count}</span>
+          <button onClick={() => counter.decrement(amounter.state.amount)}>
+            -
+          </button>
+          <button onClick={() => counter.increment(amounter.state.amount)}>
+            +
+          </button>
+        </div>
+      )}
+    </Subscribe>
+  );
+}
+
+function CounterWithAmountApp() {
+  return (
+    <Subscribe to={[AmounterContainer]}>
+      {(amounter: AmounterContainer) => (
+        <div>
+          <Counter />
+          <input
+            type="number"
+            value={amounter.state.amount}
+            onChange={event => {
+              amounter.setAmount(parseInt(event.currentTarget.value, 10));
+            }}
+          />
+        </div>
+      )}
+    </Subscribe>
+  );
+}
+
+let counter = new CounterContainer();
+let render = () => (
+  <Provider inject={[counter]}>
+    <Counter />
+  </Provider>
+);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write **/*.{js,json,md}",
     "prepublish": "yarn clean && yarn build",
     "precommit": "lint-staged",
-    "example": "parcel example/index.html"
+    "example": "parcel example/index.html",
+    "typescript": "tsc -p tsconfig.json"
   },
   "peerDependencies": {
     "create-react-context": "^0.1.5",
@@ -26,6 +27,7 @@
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
+    "@types/react": "^16.0.36",
     "babel-core": "^6.26.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.6.1",
@@ -46,7 +48,8 @@
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
     "rollup": "^0.55.3",
-    "rollup-plugin-babel": "^3.0.3"
+    "rollup-plugin-babel": "^3.0.3",
+    "typescript": "^2.7.1"
   },
   "lint-staged": {
     "*.{js,json,md}": ["prettier --write", "git add"]

--- a/src/unstated.d.ts
+++ b/src/unstated.d.ts
@@ -1,1 +1,26 @@
-// Contributions welcome
+import * as React from 'react';
+
+export class Container<State extends object> {
+  state: State;
+  setState(state: Partial<State>): void;
+  subscribe(fn: Function): void;
+  unsubscribe(fn: Function): void;
+}
+
+export interface ContainerType<State extends object> {
+  new (): Container<State>;
+}
+
+interface SubscribeProps {
+  to: ContainerType<any>[];
+  children(...instances: Container<any>[]): React.ReactNode;
+}
+
+export class Subscribe extends React.Component<SubscribeProps> {}
+
+export interface ProviderProps {
+  inject?: Container<any>[];
+  children: React.ReactNode;
+}
+
+export const Provider: React.SFC<ProviderProps>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "strict": true,
     "noEmit": true
   },
-  "include": ["src/**/*", "__test__/unstated.ts"]
+  "include": ["src/**/*", "__test__/*.tsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "lib": ["es6", "dom"],
+    "sourceMap": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "__test__/unstated.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,10 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@types/react@^16.0.36":
+  version "16.0.36"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.36.tgz#ceb5639013bdb92a94147883052e69bb2c22c69b"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -5218,6 +5222,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+typescript@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
This PR will add typings for `unstated`. Plus, some basic test to verify the typings work (`yarn typescript`).

**There is one small caveat:** You have to add the type for the container(s) in the render prop. AFAIK there is no equivalent of `$TupleMap` in Typescript and it can not infer the container types from the props either.